### PR TITLE
Modernisation for Laravel 12+ and PHP 8.3+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "ext-dom": "*",
         "ext-json": "*",
         "php": "^8.3",
+        "illuminate/database": "^12.0 || ^13.0",
         "illuminate/http": "^12.0 || ^13.0",
         "illuminate/support": "^12.0 || ^13.0",
         "illuminate/view": "^12.0 || ^13.0",

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,13 @@
     "require": {
         "ext-dom": "*",
         "ext-json": "*",
-        "php": "^8.1",
+        "php": "^8.3",
+        "illuminate/http": "^12.0 || ^13.0",
+        "illuminate/support": "^12.0 || ^13.0",
+        "illuminate/view": "^12.0 || ^13.0",
         "rybakit/msgpack": "^0.9.1",
         "spatie/array-to-xml": "^3.1.3",
-        "symfony/yaml": "^6.1.6"
+        "symfony/yaml": "^7.0 || ^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,13 @@
-Check full documentation here: [opensource.duma.sh/libraries/php/laravel-content-negotiable-responses](https://opensource.duma.sh/libraries/php/laravel-content-negotiable-responses)
+# Content Negotiable Responses for Laravel
+
+Laravel helpers for creating HTTP responses that automatically negotiate content type based on the client's `Accept` header (JSON, XML, YAML, MsgPack, HTML).
+
+Full documentation: [opensource.duma.sh/libraries/php/laravel-content-negotiable-responses](https://opensource.duma.sh/libraries/php/laravel-content-negotiable-responses)
 
 ## Requirements
 
 - PHP `^8.3`
 - Laravel `^12.0 || ^13.0`
-- symfony/yaml `^7.0 || ^8.0`
 
 ## Installation
 
@@ -12,124 +15,21 @@ Check full documentation here: [opensource.duma.sh/libraries/php/laravel-content
 composer require kduma/content-negotiable-responses
 ```
 
-## Content Formats (for `ArrayResponse` and `BasicViewResponse`)
-
-Currently supported formats are:
- - `text/plain` (disabled by default, to enable it in your custom class implement `TextResponseInterface`) - resulting response will be output of built-in PHP function `print_r`
- - `application/json` -  resulting response will be output of built-in PHP function `json_encode`
- - `application/yaml` - resulting response will be generated using [symfony/yaml](https://packagist.org/packages/symfony/yaml) package
- - `application/xml` - resulting response will be generated using [spatie/array-to-xml](https://packagist.org/packages/spatie/array-to-xml) package
- - `application/msgpack` - resulting response will be generated using [rybakit/msgpack](https://packagist.org/packages/rybakit/msgpack) package
- - `text/html` (only for `BasicViewResponse`) - resulting response will be generated using view provided to constructor with passed data array
-
 ## Usage
 
-### Basic Array Usage (for API responses)
-
 ```php
-Route::get('/test', function () {
+// Returns JSON, XML, YAML or MsgPack depending on the Accept header
+Route::get('/api/data', function () {
     return new \KDuma\ContentNegotiableResponses\ArrayResponse([
         'success' => true,
         'timestamp' => time(),
     ]);
 });
-```
-As the result, response will be formatted accordingly to acceptable formats passed in `Accept` HTTP header or as JSON if not specified.
 
-### Basic View Usage (for Web and API responses)
-
-```php
+// Returns HTML in browsers, JSON/XML/YAML in API clients
 Route::get('/', function () {
     return new \KDuma\ContentNegotiableResponses\BasicViewResponse('welcome', [
-        'success' => true,
-        'timestamp' => time(),
+        'user' => auth()->user(),
     ]);
 });
-```
-
-### Customized Usage
-
-```php
-namespace App\Http\Responses;
-
-use KDuma\ContentNegotiableResponses\BaseViewResponse;
-use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Http\Request;
-
-class UsersListResponse extends BaseViewResponse
-{
-    public $users;
-
-    public function __construct(Collection $users)
-    {
-        $this->users = $users;
-    }
-
-    protected function generateView(Request $request)
-    {
-        return $this->view('users.list');
-    }
-}
-
-Route::get('/users', function () {
-    return new \App\Http\Responses\UsersListResponse(\App\User::all());
-});
-```
-
-As the result, when opening in web browser, there will be rendered `users.list` view with passed all public properties to it.
-In non HTML clients (specyfing other `Accept` headers) will get serialized public properties (in any supported format), for example:
-
-```json
-{
-    "users": [
-        {
-            "name": "user 1",
-            "email": "user1@localhost"
-        },
-        {
-            "name": "user 2",
-            "email": "user2@localhost"
-        },
-        {
-            "name": "user 3",
-            "email": "user3@localhost"
-        }
-    ]
-}
-```
-
-If you want to customize serialized array, you need to override `getDataArray` method:
-
-```php
-/**
- * @return array
- */
-protected function getDataArray() {
-	return [
-		'my_super_users_collection' => $this->users->toArray(),
-		'hello' => true
-	];
-}
-```
-
-Then the result will be:
-
-```json
-{
-    "my_super_users_collection": [
-        {
-            "name": "user 1",
-            "email": "user1@localhost"
-        },
-        {
-            "name": "user 2",
-            "email": "user2@localhost"
-        },
-        {
-            "name": "user 3",
-            "email": "user3@localhost"
-        }
-    ],
-    "hello": true
-}
 ```

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,11 @@
 Check full documentation here: [opensource.duma.sh/libraries/php/laravel-content-negotiable-responses](https://opensource.duma.sh/libraries/php/laravel-content-negotiable-responses)
 
+## Requirements
+
+- PHP `^8.3`
+- Laravel `^12.0 || ^13.0`
+- symfony/yaml `^7.0 || ^8.0`
+
 ## Installation
 
 ```bash

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,9 @@
 # Content Negotiable Responses for Laravel
 
+[![Latest Stable Version](https://poser.pugx.org/kduma/content-negotiable-responses/v/stable.svg)](https://packagist.org/packages/kduma/content-negotiable-responses)
+[![Total Downloads](https://poser.pugx.org/kduma/content-negotiable-responses/downloads.svg)](https://packagist.org/packages/kduma/content-negotiable-responses)
+[![License](https://poser.pugx.org/kduma/content-negotiable-responses/license.svg)](https://packagist.org/packages/kduma/content-negotiable-responses)
+
 Laravel helpers for creating HTTP responses that automatically negotiate content type based on the client's `Accept` header (JSON, XML, YAML, MsgPack, HTML).
 
 Full documentation: [opensource.duma.sh/libraries/php/laravel-content-negotiable-responses](https://opensource.duma.sh/libraries/php/laravel-content-negotiable-responses)

--- a/src/ArrayResponse.php
+++ b/src/ArrayResponse.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 
 namespace KDuma\ContentNegotiableResponses;
 

--- a/src/BaseArrayResponse.php
+++ b/src/BaseArrayResponse.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 
 namespace KDuma\ContentNegotiableResponses;
 

--- a/src/BaseResponse.php
+++ b/src/BaseResponse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KDuma\ContentNegotiableResponses;
 
 use Illuminate\Http\Response;

--- a/src/BaseViewResponse.php
+++ b/src/BaseViewResponse.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 
 namespace KDuma\ContentNegotiableResponses;
 

--- a/src/BasicViewResponse.php
+++ b/src/BasicViewResponse.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 
 namespace KDuma\ContentNegotiableResponses;
 

--- a/src/Helpers/ResourceResponseHelper.php
+++ b/src/Helpers/ResourceResponseHelper.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KDuma\ContentNegotiableResponses\Helpers;
 
 use Illuminate\Contracts\Support\Arrayable;

--- a/src/Interfaces/HtmlResponseInterface.php
+++ b/src/Interfaces/HtmlResponseInterface.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 
 namespace KDuma\ContentNegotiableResponses\Interfaces;
 

--- a/src/Interfaces/JsonResponseInterface.php
+++ b/src/Interfaces/JsonResponseInterface.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 
 namespace KDuma\ContentNegotiableResponses\Interfaces;
 

--- a/src/Interfaces/MsgPackResponseInterface.php
+++ b/src/Interfaces/MsgPackResponseInterface.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 
 namespace KDuma\ContentNegotiableResponses\Interfaces;
 

--- a/src/Interfaces/TextResponseInterface.php
+++ b/src/Interfaces/TextResponseInterface.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 
 namespace KDuma\ContentNegotiableResponses\Interfaces;
 

--- a/src/Interfaces/XmlResponseInterface.php
+++ b/src/Interfaces/XmlResponseInterface.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 
 namespace KDuma\ContentNegotiableResponses\Interfaces;
 

--- a/src/Interfaces/YamlResponseInterface.php
+++ b/src/Interfaces/YamlResponseInterface.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 
 namespace KDuma\ContentNegotiableResponses\Interfaces;
 

--- a/src/Traits/DiscoversPublicProperties.php
+++ b/src/Traits/DiscoversPublicProperties.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 
 namespace KDuma\ContentNegotiableResponses\Traits;
 


### PR DESCRIPTION
## Summary
- Bump PHP requirement to `^8.3`
- Add `illuminate/http`, `illuminate/support`, `illuminate/view` `^12.0 || ^13.0`
- Bump `symfony/yaml` to `^7.0 || ^8.0`
- Add `declare(strict_types=1)` to all source files
- Add full type hints to all classes